### PR TITLE
QUICK-FIX Change test of audit contains snapshotable control after deleting original control

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -239,6 +239,7 @@ dashboard-js-files:
   - components/add-object-button/add-object-button.js
   - components/effective-dates/effective-dates.js
   - components/snapshotter/revisions-comparer.js
+  - components/snapshotter/open-original-link.js
   - components/snapshotter/scope-update.js
   - components/info-pin-buttons/info-pin-buttons.js
   - components/questions-link/questions-link.js
@@ -561,6 +562,7 @@ dashboard-js-template-files:
   - mapper/relevant_filter.mustache
   - quick_form/confirm_buttons.mustache
   - snapshots/dropdown_menu.mustache
+  - snapshots/open_original_link.mustache
   - snapshots/tree_add_item.mustache
 
 dashboard-css-files:

--- a/src/ggrc/assets/javascripts/components/snapshotter/open-original-link.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/open-original-link.js
@@ -1,0 +1,58 @@
+/*!
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, $) {
+  'use strict';
+
+  GGRC.Components('openOriginalLink', {
+    tag: 'open-original-link',
+    template: can.view(
+      GGRC.mustache_path +
+      '/snapshots/open_original_link.mustache'
+    ),
+    viewModel: {
+      originalDeleted: false,
+      define: {
+        revisions: {
+          set: function (value) {
+            var lastRevision;
+
+            if (!value || value.length === 0) {
+              return;
+            }
+
+            lastRevision = value[value.length - 1];
+            this.checkOriginal(lastRevision.id);
+          }
+        }
+      },
+      checkOriginal: function (revisionId) {
+        var self = this;
+        var queryAPI = GGRC.Utils.QueryAPI;
+        var filter = {
+          expression: {
+            op: {name: '='},
+            left: 'id',
+            right: revisionId
+          }
+        };
+
+        var params = queryAPI.buildParam(
+          'Revision', {}, undefined, undefined, filter);
+
+        queryAPI.makeRequest({data: [params]})
+          .then(function (response) {
+            var revision = response[0].Revision;
+
+            if (revision.count > 0) {
+              self.attr('originalDeleted',
+                revision.values[0].action === 'deleted');
+            }
+          }
+        );
+      }
+    }
+  });
+})(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/components/tests/open_original_link_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/open_original_link_spec.js
@@ -1,0 +1,77 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.openOriginalLink', function () {
+  'use strict';
+
+  describe('originalDeleted property', function () {
+    var viewModel;
+    var revisions = [
+      {id: 1, href: '/revisions/1'},
+      {id: 2, href: '/revisions/2'}
+    ];
+
+    beforeEach(function () {
+      viewModel = GGRC.Components.getViewModel('openOriginalLink');
+    });
+
+    function setSpyOnForMakeRequest(returnValue) {
+      spyOn(GGRC.Utils.QueryAPI, 'makeRequest')
+        .and.returnValue(new can.Deferred().resolve(returnValue));
+    }
+
+    function buildRevisionObject(action) {
+      return [
+        {
+          Revision: {
+            count: 1,
+            values: [
+              {action: action}
+            ]
+          }
+        }
+      ];
+    }
+
+    it('originalDeleted should be false. "revisions" array is empty',
+      function (done) {
+        viewModel.attr('revisions', []);
+
+        setTimeout(function () {
+          expect(viewModel.attr('originalDeleted')).toBe(false);
+          done();
+        }, 1);
+      }
+    );
+
+    it('originalDeleted should be false. "modified" action',
+      function (done) {
+        var makeRequestResponse = buildRevisionObject('modified');
+
+        setSpyOnForMakeRequest(makeRequestResponse);
+        viewModel.attr('revisions', revisions);
+
+        setTimeout(function () {
+          expect(viewModel.attr('originalDeleted')).toBe(false);
+          done();
+        }, 1);
+      }
+    );
+
+    it('originalDeleted should be true. "deleted" action',
+      function (done) {
+        var makeRequestResponse = buildRevisionObject('deleted');
+
+        setSpyOnForMakeRequest(makeRequestResponse);
+        viewModel.attr('revisions', revisions);
+
+        setTimeout(function () {
+          expect(viewModel.attr('originalDeleted')).toBe(true);
+          done();
+        }, 1);
+      }
+    );
+  });
+});

--- a/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
@@ -61,10 +61,9 @@ TODO: Temporary disabled until snapshot view is added.
             {{/using}}
 
             <li>
-                <a href="{{instance.originalLink}}">
-                    <i class="fa fa-long-arrow-right"></i>
-                    View original {{instance.class.title_singular}}
-                </a>
+                <open-original-link
+                    revisions="instance.snapshot.revisions">
+                </open-original-link>
             </li>
         </ul>
     </div>

--- a/src/ggrc/assets/mustache/snapshots/open_original_link.mustache
+++ b/src/ggrc/assets/mustache/snapshots/open_original_link.mustache
@@ -1,0 +1,16 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#if originalDeleted}}
+    <a href="#" class="disabled-original disabled">
+        <i class="fa fa-long-arrow-right"></i>
+        Original {{instance.class.title_singular}} is deleted
+    </a>
+{{else}}
+    <a href="{{instance.originalLink}}">
+        <i class="fa fa-long-arrow-right"></i>
+        View original {{instance.class.title_singular}}
+    </a>
+{{/if}}

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -200,6 +200,11 @@ select {
   }
 }
 
+.disabled-original {
+  color: black;
+  opacity: 0.4;
+}
+
 // show hide
 .showhide {
   float:left;

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -34,6 +34,8 @@ class Common(object):
   SPINNY = "SPINNY_"
   ACCORDION_MEMBERS = "ACCORDION_MEMBERS_"
   TOGGLE = "TOGGLE_"
+  # attrs values
+  DISABLED_VALUE = "disabled-original disabled"
 
 
 class Login(object):

--- a/test/selenium/src/lib/element/widget_info.py
+++ b/test/selenium/src/lib/element/widget_info.py
@@ -33,12 +33,16 @@ class CommonDropdownSettings(base.Component):
     """Select open button in 3BBS dropdown modal."""
     base.Button(self._driver, self.open_locator).click()
 
-  def is_open_exist(self):
-    """Find open button in 3BBS dropdown modal.
-    Return: True if open button is exist,
-            False if open button is not exist.
+  def is_open_enabled(self):
+    """Find open button in 3BBS dropdown modal and check if it enabled.
+    Return:
+    True if disabled attribute value does not exist for parent element of open,
+    False if disabled attribute value exist for parent element of open.
     """
-    return selenium_utils.is_element_exist(self._driver, self.open_locator)
+    parent_element_of_open = selenium_utils.get_parent_element(
+        self._driver, self._driver.find_element(*self.open_locator))
+    return selenium_utils.is_value_in_attr(
+        parent_element_of_open, value=locator.Common.DISABLED_VALUE)
 
   def select_edit(self):
     """Select edit button in 3BBS dropdown modal.

--- a/test/selenium/src/lib/page/modal/update_object.py
+++ b/test/selenium/src/lib/page/modal/update_object.py
@@ -21,6 +21,7 @@ class CompareUpdateObjectModal(base.Modal):
 
   def confirm_update(self):
     """Confirm update object."""
+    selenium_utils.wait_for_js_to_load(self._driver)
     self.button_update.click()
     selenium_utils.get_when_invisible(
         self._driver, self._locators.BUTTON_CONFIRM)

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -171,7 +171,7 @@ class BaseWebUiService(object):
     """
     # pylint: disable=invalid-name
     obj_info_panel = self.open_info_panel_of_obj_by_title(src_obj, obj)
-    return obj_info_panel.open_info_3bbs().is_open_exist()
+    return obj_info_panel.open_info_3bbs().is_open_enabled()
 
   def filter_list_objs_from_tree_view(self, src_obj, filter_exp):
     """Filter by specified criteria and return list of objects from Tree

--- a/test/selenium/src/lib/utils/selenium_utils.py
+++ b/test/selenium/src/lib/utils/selenium_utils.py
@@ -172,6 +172,11 @@ def scroll_into_view(driver, element):
   return element
 
 
+def get_parent_element(driver, element):
+  """Get parent element of current element using JS."""
+  return driver.execute_script("return arguments[0].parentNode;", element)
+
+
 def wait_for_js_to_load(driver):
   """Wait until there all JS are completed."""
   return wait_until_condition(

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -145,14 +145,13 @@ class TestSnapshots(base.Test):
         messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
 
   @pytest.mark.smoke_tests
-  @pytest.mark.skipif(True, reason="Issue in app GGRC-1196")
-  def test_audit_contains_snapshotable_control_after_deleting_original_control(
+  def test_audit_contains_snapshotable_control_after_deleting_control(
       self, create_audit_and_delete_original_control, selenium
   ):
-    """Check via UI that Audit contains snapshotable Control even after
-    deleting original control.
-    Snapshot does not have links to update version to latest state
-    and to view original Control under Program.
+    """Check via UI that Audit contains snapshotable Control after
+    deleting original Control but without updating to latest version.
+    Check of snapshotable Control has link to update version to latest state
+    and link to view original Control is disabled.
     Preconditions:
     - Execution and return of fixture
       'create_audit_and_delete_original_control'.
@@ -160,6 +159,39 @@ class TestSnapshots(base.Test):
     audit_with_one_control = create_audit_and_delete_original_control
     audit = audit_with_one_control["audit"]
     expected_control = audit_with_one_control["control"]
+    actual_controls_tab_count = (webui_service.ControlsService(selenium).
+                                 get_count_objs_from_tab(src_obj=audit))
+    assert len([expected_control]) == actual_controls_tab_count
+    actual_controls = (webui_service.ControlsService(selenium).
+                       get_list_objs_from_tree_view(src_obj=audit))
+    assert [expected_control] == actual_controls, (
+        messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
+    is_control_updateable = (webui_service.ControlsService(selenium).
+                             is_obj_updateble_via_info_panel(
+        src_obj=audit, obj=expected_control))
+    is_control_openable = (webui_service.ControlsService(selenium).
+                           is_obj_page_exist_via_info_panel(
+        src_obj=audit, obj=expected_control))
+    assert is_control_updateable is True
+    assert is_control_openable is False
+
+  @pytest.mark.smoke_tests
+  def test_update_snapshotable_ver_after_deleting_original_control(
+      self, create_audit_and_delete_original_control, selenium
+  ):
+    """Check via UI that Audit contains snapshotable Control after
+    deleting original Control and updating to latest version.
+    Check of snapshotable Control does not has link to update version to latest
+    state and link to view original Control is disabled.
+    Preconditions:
+    - Execution and return of fixture
+      'create_audit_and_delete_original_control'.
+    """
+    audit_with_one_control = create_audit_and_delete_original_control
+    audit = audit_with_one_control["audit"]
+    expected_control = audit_with_one_control["control"]
+    (webui_service.ControlsService(selenium).
+     update_obj_ver_via_info_panel(src_obj=audit, obj=expected_control))
     actual_controls_tab_count = (webui_service.ControlsService(selenium).
                                  get_count_objs_from_tab(src_obj=audit))
     assert len([expected_control]) == actual_controls_tab_count


### PR DESCRIPTION
This PR unskip and change according to actual expected behavior of existing test: "test_audit_contains_snapshotable_control_after_deleting_original_control".
