### PR TITLE
Change Page Objects according to new buttons' styles

### DIFF
--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -199,11 +199,11 @@ class CommonModalUnifiedMapper(object):
                               MODAL + " .multiselect-dropdown__input")
   FILTER_BY_STATE_DROPDOWN_OPTIONS = (By.CSS_SELECTOR,
                                       MODAL + " .multiselect-dropdown__label")
-  BUTTON_SEARCH = (By.CSS_SELECTOR, MODAL + " .filter-buttons .btn-info")
+  BUTTON_SEARCH = (By.CSS_SELECTOR, MODAL + " .filter-buttons .btn-small")
   FOUND_OBJECTS_TITLES = (By.CSS_SELECTOR, MODAL + " .flex-box .title-attr")
   FOUND_OBJECTS_CHECKBOXES = (By.CSS_SELECTOR,
                               MODAL + ' .flex-box [type="checkbox"]')
-  BUTTON_MAP_SELECTED = (By.CSS_SELECTOR, MODAL + " .btn-success")
+  BUTTON_MAP_SELECTED = (By.CSS_SELECTOR, MODAL + " .modal-footer .btn-map")
 
 
 class ModalMapObjects(CommonModalUnifiedMapper):
@@ -579,14 +579,15 @@ class ModalCommonConfirmAction(object):
   MODAL_TITLE = (By.CSS_SELECTOR, "{} .modal-header h2".format(MODAL))
   CONFIRMATION_TEXT = (By.CSS_SELECTOR, "{} .modal-body p".format(MODAL))
   # user input elements
-  BUTTON_CONFIRM = (By.CSS_SELECTOR, "{} .btn-success".format(MODAL))
+  BUTTON_CONFIRM = (By.CSS_SELECTOR,
+                    "{} .modal-footer .btn-small".format(MODAL))
 
 
 class ModalDeleteObject(ModalCommonConfirmAction):
   """Locators for Delete object modals."""
   MODAL = Common.MODAL_CONFIRM
   OBJECT_TITLE = (By.CSS_SELECTOR, "{} .modal-body span".format(MODAL))
-  BUTTON_DELETE = (By.CSS_SELECTOR, "{} .btn-danger".format(MODAL))
+  BUTTON_DELETE = ModalCommonConfirmAction.BUTTON_CONFIRM
 
 
 class ModalUpdateObject(ModalCommonConfirmAction):
@@ -896,7 +897,7 @@ class TreeView(object):
       By.CSS_SELECTOR, ".widget:not(.hidden) .tree-no-results-message")
   BUTTON_SHOW_FIELDS = "{} " + Common.TREE_HEADER + " .fa-bars"
   # user input elements
-  BUTTON_3BBS = "{} " + Common.TREE_LIST + " .btn-draft"
+  BUTTON_3BBS = "{} " + Common.TREE_LIST + " .details-wrap"
   BUTTON_CREATE = "{} " + Common.TREE_LIST + " .create-button"
   BUTTON_MAP = "{} " + Common.TREE_LIST + " .map-button"
 


### PR DESCRIPTION
This PR changed PO for TAF according to new UI elements (buttons' new styles) and fix the next failed selenium tests or PR#5551:

src.tests.test_audit_page.TestAuditPage.test_asmts_generation
src.tests.test_audit_page.TestAuditPage.test_cloned_audit_contains_new_attrs
src.tests.test_audit_page.TestAuditPage.test_non_clonable_objs_donot_move_to_cloned_audit
src.tests.test_audit_page.TestAuditPage.test_clonable_audit_related_objs_move_to_cloned_audit
src.tests.test_audit_page.TestAuditPage.test_clonable_not_audit_related_objs_move_to_cloned_audit
src.tests.test_my_work_page.TestMyWorkPage.test_horizontal_nav_bar_tabs
src.tests.test_snapshots.TestSnapshots.test_update_snapshotable_ver_after_updating_original_control
src.tests.test_snapshots.TestSnapshots.test_update_snapshotable_ver_after_deleting_original_control
src.tests.test_snapshots.TestSnapshots.test_bulk_update_audit_objects_to_latest_ver
src.tests.test_snapshots.TestSnapshots.test_search_unified_mapper[Snapshoted version is not found]ual snapshotable control is found and already mapped to audit]
src.tests.test_unified_mapper.TestProgramPage.test_mapping_controls_to_program_via_unified_mapper